### PR TITLE
Validate button state using metal-state validators

### DIFF
--- a/packages/metal-quartz-button/demos/index.html
+++ b/packages/metal-quartz-button/demos/index.html
@@ -20,7 +20,7 @@
 	<div class="row row-spacing">
 		<h1>Button</h1>
 	</div>
-	
+
 	<div class="row row-spacing">
 		<h4>Button States</h1>
 		<div id="states-block"></div>
@@ -35,7 +35,7 @@
 		<h4>Button Sizes</h1>
 		<div id="sizes-block"></div>
 	</div>
-	
+
 	<div class="row row-spacing">
 		<h4>Block Button</h1>
 		<div id="block-block"></div>
@@ -60,7 +60,7 @@
 		/*
 		 * Button States.
 		 * Once state is a reserved key for STATE, we are using style instead.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				label: 'Default Button'
@@ -119,7 +119,7 @@
 
 		/*
 		 * Disabed button.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				disabled: true,
@@ -130,7 +130,7 @@
 
 		/*
 		 * Button sizes.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				label: 'Large Button',
@@ -157,7 +157,7 @@
 
 		/*
 		 * Listening to events.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				label: 'Listening Click'
@@ -170,7 +170,7 @@
 
 		/*
 		 * Block button.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				block: true,
@@ -181,7 +181,7 @@
 
 		/*
 		 * Extending button style.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				label: 'Default Button',
@@ -192,7 +192,7 @@
 
 		/*
 		 * Extending button style.
-		 */ 
+		 */
 		new metal.MetalQuartzButton(
 			{
 				label: 'Add Button',

--- a/packages/metal-quartz-button/src/MetalQuartzButton.js
+++ b/packages/metal-quartz-button/src/MetalQuartzButton.js
@@ -1,8 +1,8 @@
 'use strict';
 
 import MetalQuartzButtonBase from './MetalQuartzButtonBase';
-import core from 'metal';
 import Soy from 'metal-soy';
+import {validators} from 'metal-state';
 
 import 'metal-quartz-icon';
 
@@ -28,7 +28,7 @@ MetalQuartzButton.STATE = {
 	 * @default false
 	 */
 	block: {
-		validator: core.isBoolean,
+		validator: validators.bool,
 		value: false
 	},
 
@@ -40,7 +40,7 @@ MetalQuartzButton.STATE = {
 	 * @default undefined
 	 */
 	icon: {
-		validator: core.isString
+		validator: validators.string
 	},
 
 	/**
@@ -52,7 +52,7 @@ MetalQuartzButton.STATE = {
 	 * @default ''
 	 */
 	size: {
-		validator: core.isString,
+		validator: validators.string,
 		value: ''
 	},
 
@@ -64,7 +64,7 @@ MetalQuartzButton.STATE = {
 	 * @default ''
 	 */
 	spritemap: {
-		validator: core.isString
+		validator: validators.string
 	},
 
 	/**
@@ -75,7 +75,7 @@ MetalQuartzButton.STATE = {
 	 * @default 'default'
 	 */
 	style: {
-		validator: core.isString,
+		validator: validators.string,
 		value: 'default'
 	}
 };

--- a/packages/metal-quartz-button/src/MetalQuartzButtonBase.js
+++ b/packages/metal-quartz-button/src/MetalQuartzButtonBase.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Component from 'metal-component';
-import core from 'metal';
+import {validators} from 'metal-state';
 
 /**
  * Metal Quartz Button Base component.
@@ -23,7 +23,7 @@ MetalQuartzButtonBase.STATE = {
 	 * @default false
 	 */
 	disabled: {
-		validator: core.isBoolean,
+		validator: validators.bool,
 		value: false
 	},
 
@@ -35,7 +35,7 @@ MetalQuartzButtonBase.STATE = {
 	 * @default ''
 	 */
 	href: {
-		validator: core.isString,
+		validator: validators.string,
 		value: ''
 	},
 
@@ -47,7 +47,7 @@ MetalQuartzButtonBase.STATE = {
 	 * @default ''
 	 */
 	label: {
-		validator: core.isString,
+		validator: validators.string,
 		value: ''
 	},
 
@@ -59,7 +59,7 @@ MetalQuartzButtonBase.STATE = {
 	 * @default ''
 	 */
 	name: {
-		validator: core.isString,
+		validator: validators.string,
 		value: ''
 	},
 
@@ -71,7 +71,7 @@ MetalQuartzButtonBase.STATE = {
 	 * @default ''
 	 */
 	type: {
-		validator: core.isString,
+		validator: validators.string,
 		value: ''
 	},
 
@@ -83,7 +83,7 @@ MetalQuartzButtonBase.STATE = {
 	 * @default ''
 	 */
 	value: {
-		validator: core.isString,
+		validator: validators.string,
 		value: ''
 	}
 };


### PR DESCRIPTION
`core.isString` and similar methods will not throw an error or notify the developer in any way if an improper value is passed to the state. 

I recommend using the metal-state validators for all quartz components going forward as they print very helpful error messages to the console.