### PR TITLE
Metal Quartz Button: make icon param an object of icon component attr…

### DIFF
--- a/packages/metal-quartz-button/demos/index.html
+++ b/packages/metal-quartz-button/demos/index.html
@@ -196,8 +196,10 @@
 		new metal.MetalQuartzButton(
 			{
 				label: 'Add Button',
-				spritemap: '../node_modules/lexicon-ux/build/images/icons/icons.svg',
-				icon: 'plus'
+				icon: {
+					spritemap: '../node_modules/lexicon-ux/build/images/icons/icons.svg',
+					symbol: 'plus'
+				}
 			},
 			'#icons-block'
 		);

--- a/packages/metal-quartz-button/src/MetalQuartzButton.js
+++ b/packages/metal-quartz-button/src/MetalQuartzButton.js
@@ -33,14 +33,15 @@ MetalQuartzButton.STATE = {
 	},
 
 	/**
-	 * The icon name required for the icons library.
+	 * Render MetalQuartzButton in the link, available options are
+	 * `elementClasses`, `spritemap`, `symbol`.
 	 * @instance
-	 * @memberof MetalQuartzIcon
-	 * @type {?string}
+	 * @memberof MetalQuartzButton
+	 * @type {?Object}
 	 * @default undefined
 	 */
 	icon: {
-		validator: validators.string
+		validator: validators.object
 	},
 
 	/**
@@ -52,17 +53,6 @@ MetalQuartzButton.STATE = {
 	 * @default undefined
 	 */
 	size: {
-		validator: validators.string
-	},
-
-	/**
-	 * The svg spritemap that will be used for loading svg icons.
-	 * @instance
-	 * @memberof MetalQuartzButton
-	 * @type {?string}
-	 * @default undefined
-	 */
-	spritemap: {
 		validator: validators.string
 	},
 

--- a/packages/metal-quartz-button/src/MetalQuartzButton.soy
+++ b/packages/metal-quartz-button/src/MetalQuartzButton.soy
@@ -7,11 +7,10 @@
 	{@param? block: bool}
 	{@param? disabled: bool}
 	{@param? href: string}
-	{@param? icon: string}
+	{@param? icon: ?}
 	{@param? label: html}
 	{@param? name: string}
 	{@param? size: string}
-	{@param? spritemap: string}
 	{@param? style: string}
 	{@param? type: string}
 	{@param? value: string}
@@ -30,13 +29,13 @@
 {/template}
 
 {template .icon}
-	{@param? icon: string}
-	{@param? spritemap: string}
+	{@param? icon: ?}
 
-	{if $icon and $spritemap}
+	{if $icon}
 		{call MetalQuartzIcon.render}
-			{param spritemap: $spritemap /}
-			{param symbol: $icon /}
+			{param elementClasses: $icon.elementClasses /}
+			{param spritemap: $icon.spritemap /}
+			{param symbol: $icon.symbol /}
 		{/call}
 	{/if}
 {/template}


### PR DESCRIPTION
This change just nests all of the icon params into one object that matches the api of the actual `MetalQuartzIcon` component. This will be consistent with how we are doing it [here](https://github.com/metal/metal-quartz-components/blob/master/packages/metal-quartz-link/src/MetalQuartzLink.soy#L55-L66).