### PR TITLE
Add alias `metal-soy` in webpack

### DIFF
--- a/packages/clay-badge/webpack.config.js
+++ b/packages/clay-badge/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-button/webpack.config.js
+++ b/packages/clay-button/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-collapse/webpack.config.js
+++ b/packages/clay-collapse/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-icon/webpack.config.js
+++ b/packages/clay-icon/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-link/webpack.config.js
+++ b/packages/clay-link/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-progress-bar/webpack.config.js
+++ b/packages/clay-progress-bar/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-select/webpack.config.js
+++ b/packages/clay-select/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',

--- a/packages/clay-sticker/webpack.config.js
+++ b/packages/clay-sticker/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
 	resolve: {
 		mainFields: ['esnext:main', 'main'],
 		alias: {
+			'metal-soy': path.resolve('./node_modules/metal-soy'),
 			'incremental-dom': path.resolve('./node_modules/incremental-dom'),
 			'metal-incremental-dom': path.resolve(
 				'./node_modules/metal-incremental-dom',


### PR DESCRIPTION
Hey, guys,

A strange webpack behavior, when we depend on packets of clay, it happens that the webpack doubles, triples ... metal and other functions, depending on the amount of dependencies. The package becomes "giant" and `soy` when registering the models, it registers in different functions within that package by the same function in different places when executed.

```javascript
register(componentCtor, templates, mainTemplate = 'render') {
```

This implies running the ** javascript ** code inside the component. For a demonstration, see pr #68. 
Run a test by adding `console.log('--execute--') ` to` clay-icon` and try to execute packages that depend on it.

The solution to the problem was the addition of a `metal-soy` alias in the webpack.