### PR TITLE
Remove size lg and xl in sticker

### DIFF
--- a/packages/clay-sticker/demos/index.html
+++ b/packages/clay-sticker/demos/index.html
@@ -135,16 +135,6 @@
 		new metal.ClaySticker(
 			{
 				label: 'JP',
-				size: 'lg',
-				static: true
-			},
-			'#sizes-block'
-		);
-
-		new metal.ClaySticker(
-			{
-				label: 'LM',
-				size: 'xl',
 				static: true
 			},
 			'#sizes-block'
@@ -231,30 +221,6 @@
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'add-cell'
 				},
-				static: true
-			},
-			'#icons-block'
-		);
-
-		new metal.ClaySticker(
-			{
-				icon: {
-					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
-					symbol: 'add-cell'
-				},
-				size: 'lg',
-				static: true
-			},
-			'#icons-block'
-		);
-
-		new metal.ClaySticker(
-			{
-				icon: {
-					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
-					symbol: 'add-cell'
-				},
-				size: 'xl',
 				static: true
 			},
 			'#icons-block'

--- a/packages/clay-sticker/src/ClaySticker.js
+++ b/packages/clay-sticker/src/ClaySticker.js
@@ -73,13 +73,13 @@ ClaySticker.STATE = {
   ]),
 
   /**
-   * Sticker size. Available sizes are `sm`, `lg`, `xl`.
+   * Sticker size. Available sizes are `sm`.
    * @instance
    * @memberof ClaySticker
    * @type {?string|undefined}
    * @default undefined
    */
-  size: Config.oneOf(['lg', 'sm', 'xl']),
+  size: Config.oneOf(['sm']),
 
   /**
    * Shape of the sticker. Available shapes are `circle`, `rounded`.

--- a/packages/clay-sticker/src/__tests__/ClaySticker.js
+++ b/packages/clay-sticker/src/__tests__/ClaySticker.js
@@ -51,22 +51,6 @@ describe('ClaySticker', function() {
     expect(sticker).toMatchSnapshot();
   });
 
-  it('should render a large sticker', () => {
-    sticker = new ClaySticker({
-      size: 'lg',
-    });
-
-    expect(sticker).toMatchSnapshot();
-  });
-
-  it('should render a extra large sticker', () => {
-    sticker = new ClaySticker({
-      size: 'xl',
-    });
-
-    expect(sticker).toMatchSnapshot();
-  });
-
   it('should render a circle sticker', () => {
     sticker = new ClaySticker({
       shape: 'circle',

--- a/packages/clay-sticker/src/__tests__/__snapshots__/ClaySticker.js.snap
+++ b/packages/clay-sticker/src/__tests__/__snapshots__/ClaySticker.js.snap
@@ -24,10 +24,6 @@ exports[`ClaySticker should render a bottom right positioned sticker 1`] = `<spa
 
 exports[`ClaySticker should render a circle sticker 1`] = `<span class="sticker sticker-primary rounded-circle"></span>`;
 
-exports[`ClaySticker should render a extra large sticker 1`] = `<span class="sticker sticker-primary sticker-xl"></span>`;
-
-exports[`ClaySticker should render a large sticker 1`] = `<span class="sticker sticker-primary sticker-lg"></span>`;
-
 exports[`ClaySticker should render a small sticker 1`] = `<span class="sticker sticker-primary sticker-sm"></span>`;
 
 exports[`ClaySticker should render a sticker with icon 1`] = `


### PR DESCRIPTION
Hey guys,

Patrick updated the sticker sizes and now only has `sm` and default.