### PR TITLE
Remove API monospaced of the ClayIcon and add support to btn-monospaced in ClayButton

### DIFF
--- a/packages/clay-alert/src/ClayAlert.soy
+++ b/packages/clay-alert/src/ClayAlert.soy
@@ -44,7 +44,6 @@
 				{param events: [ 'click': $_handleCloseClick ] /}
 				{param icon: [
 					'alignment': 'right',
-					'monospaced': false,
 					'spritemap': $spritemap,
 					'symbol': 'times'
 					] /}

--- a/packages/clay-button/demos/index.html
+++ b/packages/clay-button/demos/index.html
@@ -66,6 +66,13 @@
 		</div>
 	</div>
 
+	<div class="row row-spacing">
+		<div class="col">
+			<h4>Button monospaced</h4>
+			<div id="monospaced-block"></div>
+		</div>
+	</div>
+
 	<script type="text/javascript">
 		/*
 		 * Button States.
@@ -163,7 +170,6 @@
 			{
 				label: 'Default Icon Position',
 				icon: {
-					monospaced: true,
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'plus'
 				}
@@ -176,7 +182,6 @@
 				label: 'Icon positioned at right',
 				icon: {
 					alignment: 'right',
-					monospaced: true,
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'plus'
 				}
@@ -187,13 +192,52 @@
 		new metal.ClayButton(
 			{
 				icon: {
-					monospaced: true,
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'plus'
-				}
+				},
+				monospaced: true
 			},
 			'#icons-block'
 		);
+
+		/*
+		 * Button monospaced.
+		 */
+		 new metal.ClayButton(
+ 			{
+ 				label: 'A',
+				monospaced: true
+ 			},
+ 			'#monospaced-block'
+ 		);
+
+ 		new metal.ClayButton(
+ 			{
+ 				style: 'secondary',
+ 				label: 'B',
+				monospaced: true
+ 			},
+ 			'#monospaced-block'
+ 		);
+
+ 		new metal.ClayButton(
+ 			{
+ 				style: 'borderless',
+ 				label: 'C',
+				monospaced: true
+ 			},
+ 			'#monospaced-block'
+ 		);
+
+ 		new metal.ClayButton(
+ 			{
+ 				ariaLabel: 'My Description',
+ 				style: 'link',
+ 				label: 'D',
+				monospaced: true
+ 			},
+ 			'#monospaced-block'
+ 		);
 	</script>
 </body>
 </html>

--- a/packages/clay-button/src/ClayButton.js
+++ b/packages/clay-button/src/ClayButton.js
@@ -52,7 +52,6 @@ ClayButton.STATE = {
    */
   icon: Config.shapeOf({
     alignment: Config.oneOf(['left', 'right']),
-    monospaced: Config.bool(),
     spritemap: Config.string().required(),
     symbol: Config.string().required(),
   }),

--- a/packages/clay-button/src/ClayButton.js
+++ b/packages/clay-button/src/ClayButton.js
@@ -75,6 +75,15 @@ ClayButton.STATE = {
   label: Config.any(),
 
   /**
+   * Flag to indicate if button should be monospaced.
+   * @instance
+   * @memberof ClayButton
+   * @type {?bool}
+   * @default false
+   */
+  monospaced: Config.bool().value(false),
+
+  /**
    * The name attribute value of the element.
    * @instance
    * @memberof ClayButton

--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -10,7 +10,6 @@
 	{@param? elementClasses: string}
 	{@param? icon: [
 		alignment: string,
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}
@@ -53,7 +52,6 @@
 {template .content}
 	{@param? icon: [
 		alignment: string,
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}
@@ -82,13 +80,11 @@
 {template .icon}
 	{@param? icon: [
 		alignment: string,
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}
 
 	{call ClayIcon.render}
-		{param monospaced: $icon.monospaced /}
 		{param spritemap: $icon.spritemap /}
 		{param symbol: $icon.symbol /}
 	{/call}
@@ -104,7 +100,6 @@
 	{@param? elementClasses: string}
 	{@param? icon: [
 		alignment: string,
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}

--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -15,6 +15,7 @@
 	]}
 	{@param? id: string}
 	{@param? label: html|string}
+	{@param? monospaced: bool}
 	{@param? name: string}
 	{@param? size: string}
 	{@param? style: string}
@@ -30,6 +31,7 @@
 			{param icon: $icon /}
 			{param id: $id /}
 			{param label: $label /}
+			{param monospaced: $monospaced /}
 			{param name: $name /}
 			{param size: $size /}
 			{param style: $style /}
@@ -105,6 +107,7 @@
 	]}
 	{@param? id: string}
 	{@param? label: html|string}
+	{@param? monospaced: bool}
 	{@param? name: string}
 	{@param? size: string}
 	{@param? style: string}
@@ -118,6 +121,9 @@
 		{/if}
 		{if $elementClasses}
 			{sp}{$elementClasses}
+		{/if}
+		{if $monospaced}
+			{sp}btn-monospaced
 		{/if}
 		{if $size}
 			{sp}btn-{$size}

--- a/packages/clay-button/src/__tests__/ClayButton.js
+++ b/packages/clay-button/src/__tests__/ClayButton.js
@@ -83,7 +83,6 @@ describe('ClayButton', function() {
   it('should render a button with icon', function() {
     button = new ClayButton({
       icon: {
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },
@@ -92,10 +91,21 @@ describe('ClayButton', function() {
     expect(button).toMatchSnapshot();
   });
 
+  it('should render a button with icon and monospaced true', function() {
+    button = new ClayButton({
+      icon: {
+        spritemap: 'icons.svg',
+        symbol: 'plus',
+      },
+      monospaced: true,
+    });
+
+    expect(button).toMatchSnapshot();
+  });
+
   it('should render a button with icon and label', function() {
     button = new ClayButton({
       icon: {
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },
@@ -109,7 +119,6 @@ describe('ClayButton', function() {
     button = new ClayButton({
       icon: {
         alignment: 'right',
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },

--- a/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
@@ -8,7 +8,7 @@ exports[`ClayButton should render a button with custom classes 1`] = `<button cl
 
 exports[`ClayButton should render a button with icon 1`] = `
 <button class="btn btn-primary" aria-label="plus">
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>
 </button>
@@ -16,9 +16,17 @@ exports[`ClayButton should render a button with icon 1`] = `
 
 exports[`ClayButton should render a button with icon and label 1`] = `
 <button class="btn btn-primary">
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>Label</button>
+`;
+
+exports[`ClayButton should render a button with icon and monospaced true 1`] = `
+<button class="btn btn-monospaced btn-primary" aria-label="plus">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
+    <use xlink:href="icons.svg#plus"></use>
+  </svg>
+</button>
 `;
 
 exports[`ClayButton should render a button with id 1`] = `<button class="btn btn-primary" id="myButton"></button>`;
@@ -29,7 +37,7 @@ exports[`ClayButton should render a button with label and ariaLabel 1`] = `<butt
 
 exports[`ClayButton should render a button with label and icon 1`] = `
 <button class="btn btn-primary">Label
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>
 </button>

--- a/packages/clay-dropdown/src/ClayDropdownBase.soy
+++ b/packages/clay-dropdown/src/ClayDropdownBase.soy
@@ -83,12 +83,11 @@
 			<div class="input-group-input">
 				<input aria-label="Search for..." class="form-control" data-oninput="_handleSearch" placeholder="Search for..." type="text" ref="searchInput">
 			</div>
-			
+
 			<span class="input-group-inset-item">
 				{call ClayButton.render}
 					{param icon: [
 						'alignment': 'left',
-						'monospaced': false,
 						'spritemap': $spritemap,
 						'symbol': 'search'
 					] /}
@@ -246,7 +245,7 @@
 					{sp}disabled
 				{/if}
 			"
-			
+
 			{if $disabled}
 				href="javascript:;"
 			{else}

--- a/packages/clay-icon/demos/index.html
+++ b/packages/clay-icon/demos/index.html
@@ -10,7 +10,7 @@
 			body {
 				background-color: #FFF;
 			}
-	
+
 			.row {
 				margin-bottom: 20px;
 			}
@@ -28,7 +28,6 @@
 
 		for (var i = 0; i < icons.length; i++) {
 			new metal.ClayIcon({
-				monospaced: true,
 				spritemap: spritemap,
 				symbol: icons[i]
 			}, '#clayIcons');
@@ -38,7 +37,6 @@
 
 		for (var j = 0; j < icons.length; j++) {
 			new metal.ClayIcon({
-				monospaced: true,
 				spritemap: spritemap,
 				symbol: icons[j]
 			}, '#clayIcons');

--- a/packages/clay-icon/src/ClayIcon.js
+++ b/packages/clay-icon/src/ClayIcon.js
@@ -25,15 +25,6 @@ ClayIcon.STATE = {
   id: Config.string(),
 
   /**
-   * Flag to indicate if the icon should be monospaced.
-   * @instance
-   * @memberof ClayIcon
-   * @type {?bool}
-   * @default false
-   */
-  monospaced: Config.bool().value(false),
-
-  /**
    * The path to the SVG spritemap file containing the icons.
    * @instance
    * @memberof ClayIcon

--- a/packages/clay-icon/src/ClayIcon.soy
+++ b/packages/clay-icon/src/ClayIcon.soy
@@ -7,15 +7,11 @@
 	{@param spritemap: string}
 	{@param symbol: string}
 	{@param? id: string}
-	{@param? monospaced: bool}
 
 	{let $attributes kind="attributes"}
 		aria-hidden="true"
 		class="lexicon-icon
 			{sp}lexicon-icon-{$symbol}
-			{if $monospaced}
-				{sp}icon-monospaced
-			{/if}
 		"
 		{if $id}
 			id="{$id}"

--- a/packages/clay-icon/src/__tests__/ClayIcon.js
+++ b/packages/clay-icon/src/__tests__/ClayIcon.js
@@ -20,26 +20,6 @@ describe('ClayIcon', function() {
     expect(clayIcon).toMatchSnapshot();
   });
 
-  it('should render a monospaced `add-cell` icon', () => {
-    clayIcon = new ClayIcon({
-      monospaced: true,
-      spritemap: spritemap,
-      symbol: 'add-cell',
-    });
-
-    expect(clayIcon).toMatchSnapshot();
-  });
-
-  it('should render a not monospaced `add-cell` icon', () => {
-    clayIcon = new ClayIcon({
-      monospaced: false,
-      spritemap: spritemap,
-      symbol: 'add-cell',
-    });
-
-    expect(clayIcon).toMatchSnapshot();
-  });
-
   it('should render a `add-cell` icon with id', () => {
     clayIcon = new ClayIcon({
       id: 'myIcon',

--- a/packages/clay-icon/src/__tests__/__snapshots__/ClayIcon.js.snap
+++ b/packages/clay-icon/src/__tests__/__snapshots__/ClayIcon.js.snap
@@ -11,15 +11,3 @@ exports[`ClayIcon should render a \`add-cell\` icon with id 1`] = `
   <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#add-cell"></use>
 </svg>
 `;
-
-exports[`ClayIcon should render a monospaced \`add-cell\` icon 1`] = `
-<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell icon-monospaced">
-  <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#add-cell"></use>
-</svg>
-`;
-
-exports[`ClayIcon should render a not monospaced \`add-cell\` icon 1`] = `
-<svg aria-hidden="true" class="lexicon-icon lexicon-icon-add-cell">
-  <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#add-cell"></use>
-</svg>
-`;

--- a/packages/clay-label/src/ClayLabel.soy
+++ b/packages/clay-label/src/ClayLabel.soy
@@ -63,7 +63,6 @@
 			{param events: [ 'click': $_handleCloseButtonClick] /}
 			{param icon: [
 				'alignment': 'right',
-				'monospaced': false,
 				'spritemap': $spritemap,
 				'symbol': 'times'
 			] /}

--- a/packages/clay-link/demos/index.html
+++ b/packages/clay-link/demos/index.html
@@ -10,7 +10,7 @@
 		body {
 			background-color: #FFF;
 		}
-		
+
 		a { margin-right: 15px; }
 
 		.row {
@@ -95,7 +95,6 @@
 			{
 				href: '#1',
 				icon: {
-					monospaced: true,
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'add-cell'
 				},
@@ -109,7 +108,6 @@
 				href: '#1',
 				icon: {
 					alignment: 'right',
-					monospaced: true,
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'add-cell'
 				},
@@ -124,7 +122,6 @@
 				href: '#1',
 				icon: {
 					alignment: 'right',
-					monospaced: true,
 					spritemap: '../../../node_modules/clay/build/images/icons/icons.svg',
 					symbol: 'add-cell'
 				}

--- a/packages/clay-link/src/ClayLink.js
+++ b/packages/clay-link/src/ClayLink.js
@@ -62,7 +62,6 @@ ClayLink.STATE = {
    */
   icon: Config.shapeOf({
     alignment: Config.oneOf(['left', 'right']),
-    monospaced: Config.bool(),
     spritemap: Config.string().required(),
     symbol: Config.string().required(),
   }),

--- a/packages/clay-link/src/ClayLink.soy
+++ b/packages/clay-link/src/ClayLink.soy
@@ -11,7 +11,6 @@
 	{@param? href: string}
 	{@param? icon: [
 		alignment: string,
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}
@@ -83,13 +82,11 @@
 {template .icon}
 	{@param? icon: [
 		alignment: string,
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}
 
 	{call ClayIcon.render}
-		{param monospaced: $icon.monospaced /}
 		{param spritemap: $icon.spritemap /}
 		{param symbol: $icon.symbol /}
 	{/call}

--- a/packages/clay-link/src/__tests__/ClayLink.js
+++ b/packages/clay-link/src/__tests__/ClayLink.js
@@ -74,7 +74,6 @@ describe('ClayLink', function() {
   it('should render a link with icon', () => {
     link = new ClayLink({
       icon: {
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },
@@ -86,7 +85,6 @@ describe('ClayLink', function() {
   it('should render a link with icon and label', () => {
     link = new ClayLink({
       icon: {
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },
@@ -100,7 +98,6 @@ describe('ClayLink', function() {
     link = new ClayLink({
       icon: {
         alignment: 'right',
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },

--- a/packages/clay-link/src/__tests__/__snapshots__/ClayLink.js.snap
+++ b/packages/clay-link/src/__tests__/__snapshots__/ClayLink.js.snap
@@ -22,7 +22,7 @@ exports[`ClayLink should render a link with href 1`] = `<a href="http://www.life
 
 exports[`ClayLink should render a link with icon 1`] = `
 <a>
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>
 </a>
@@ -30,7 +30,7 @@ exports[`ClayLink should render a link with icon 1`] = `
 
 exports[`ClayLink should render a link with icon and label 1`] = `
 <a>
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>My Link</a>
 `;
@@ -39,7 +39,7 @@ exports[`ClayLink should render a link with id 1`] = `<a id="myLink"></a>`;
 
 exports[`ClayLink should render a link with label and icon 1`] = `
 <a>My Link
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>
 </a>

--- a/packages/clay-sticker/src/ClaySticker.js
+++ b/packages/clay-sticker/src/ClaySticker.js
@@ -24,7 +24,6 @@ ClaySticker.STATE = {
    * @default undefined
    */
   icon: Config.shapeOf({
-    monospaced: Config.bool().value(false),
     spritemap: Config.string().required(),
     symbol: Config.string().required(),
   }),

--- a/packages/clay-sticker/src/ClaySticker.soy
+++ b/packages/clay-sticker/src/ClaySticker.soy
@@ -5,7 +5,6 @@
  */
 {template .render}
 	{@param? icon: [
-		monospaced: bool,
 		spritemap: string,
 		symbol: string
 	]}
@@ -45,7 +44,6 @@
 	<span {$attributes}>
 		{if $icon}
 			{call ClayIcon.render}
-				{param monospaced: $icon.monospaced /}
 				{param spritemap: $icon.spritemap /}
 				{param symbol: $icon.symbol /}
 			{/call}

--- a/packages/clay-sticker/src/__tests__/ClaySticker.js
+++ b/packages/clay-sticker/src/__tests__/ClaySticker.js
@@ -18,7 +18,6 @@ describe('ClaySticker', function() {
   it('should render a sticker with icon', () => {
     sticker = new ClaySticker({
       icon: {
-        monospaced: true,
         spritemap: 'icons.svg',
         symbol: 'plus',
       },

--- a/packages/clay-sticker/src/__tests__/__snapshots__/ClaySticker.js.snap
+++ b/packages/clay-sticker/src/__tests__/__snapshots__/ClaySticker.js.snap
@@ -32,7 +32,7 @@ exports[`ClaySticker should render a small sticker 1`] = `<span class="sticker s
 
 exports[`ClaySticker should render a sticker with icon 1`] = `
 <span class="sticker sticker-primary">
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus icon-monospaced">
+  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
     <use xlink:href="icons.svg#plus"></use>
   </svg>
 </span>


### PR DESCRIPTION
This resolves #122.

- Remove API monospaced of the ClayIcon
- Add support the btn-monospaced in ClayButton
- Remove the monospaced pass to the icon, for dependent packages of the ClayIcon.