### PR TITLE
IFI-151 Show coverage the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier-eslint packages/clay-*/src/*.js packages/clay-*/src/**/*.js",
     "start": "http-server . -p 4000",
-    "test": "lerna run soy && jest && npm run a11y"
+    "test": "lerna run soy && jest --coverage && npm run a11y"
   },
   "devDependencies": {
     "babel-preset-metal": "^4.1.0",


### PR DESCRIPTION
### Disclaimer
Just changing so that jest shows the coverage of the tests.

### Coveralls
I think it's interesting to be able to show the coverage status of our tests and to follow through an interface as easy access.

[coveralls](https://coveralls.io/features) is a tool that can help us when we send some PR that add some functionality and we do not add tests and our coverage drops, the tool always sends a message showing how much pr impacts on coverage. In addition to other interesting features.
![image](https://user-images.githubusercontent.com/13750819/33225670-d7b3fb9a-d15a-11e7-805b-39d6bb75f5e5.png)

What do you think about this?