### PR TITLE
Create checkbox label extension with deltemplates

### DIFF
--- a/packages/clay-checkbox/src/ClayCheckbox.js
+++ b/packages/clay-checkbox/src/ClayCheckbox.js
@@ -96,6 +96,15 @@ ClayCheckbox.STATE = {
 	label: Config.any().required(),
 
 	/**
+	 * Name of the label template variant.
+	 * @instance
+	 * @memberof ClayCheckbox
+	 * @type {?string}
+	 * @default undefined
+	 */
+	labelVariant: Config.string(),
+
+	/**
 	 * Name to be applied to the element.
 	 * @instance
 	 * @memberof ClayCheckbox

--- a/packages/clay-checkbox/src/ClayCheckbox.soy
+++ b/packages/clay-checkbox/src/ClayCheckbox.soy
@@ -12,6 +12,7 @@
 	{@param? id: string}
 	{@param? indeterminate: bool}
 	{@param? inline: bool}
+	{@param? labelVariant: string}
 	{@param? name: string}
 	{@param? value: string}
 
@@ -37,6 +38,7 @@
 			{param disabled: $disabled /}
 			{param hideLabel: $hideLabel /}
 			{param label: $label /}
+			{param labelVariant: $labelVariant /}
 			{param name: $name /}
 			{param value: $value /}
 		{/call}
@@ -51,6 +53,7 @@
 	{@param? checked: bool}
 	{@param? disabled: bool}
 	{@param? hideLabel: bool}
+	{@param? labelVariant: string}
 	{@param? name: string}
 	{@param? value: string}
 
@@ -82,6 +85,14 @@
 
 		<span class="custom-control-indicator"></span>
 
+		{delcall ClayCheckbox.Label variant="$labelVariant" data="all" /}
+	</label>
+{/template}
+
+{template .label}
+		{@param label: html|string}
+		{@param? hideLabel: bool}
+
 		{let $spanLabelClasses kind="text"}
 			custom-control-description
 			{if $hideLabel}
@@ -90,5 +101,8 @@
 		{/let}
 
 		<span class="{$spanLabelClasses}">{$label}</span>
-	</label>
 {/template}
+
+{deltemplate ClayCheckbox.Label}
+	{call .label data="all" /}
+{/deltemplate}


### PR DESCRIPTION
## Why this?

As @jbalsas proposed in https://github.com/metal/metal-clay-components/issues/182#issuecomment-348138332 the best way to extend a component to fit our concrete needs is with deltemplates.

## Why don't do it in this way?

This can be done by simply creating a deltemplate as an interface, with the params it's going to receive declared and then create variants in our modules, something like:

`ClayCheckbox.soy`
```soy
{template .render}
   {delcall ClayCheckbox.Label variant='{$labelVariant}'}
      {param label: $label /}
   {/delcall}
{/template}

{deltemplate ClayCheckbox.Label}
   {@param label: html|string}

   <span class="{$spanLabelClasses}">{$label}</span>
{/deltemplate}
```

`ClayCard.soy`
```soy
{template .render}
...
   {call Checkbox.render}
      {param label: 'myLabel' /}
      {param labelVariant: 'card' /}
   {/call}
...
{/template}

{deltemplate ClayCheckbox.Label variant="'card'"}
   {@param label: html|string}

   <div class="card">
      .... {$label} ....
   </div>
{/deltemplate}
```

But with this approach we are limited by the contract with the default implementation of the `ClayCheckbox.Label`, I mean, if we want to pass it a parameter `coolParameter` we only can do it by adding it (obviously as optional) in the default implementation and all over the rest of implementations to comply the contract.

## Why to do it in this way?

So I prefer the following approach:

`ClayCheckbox.soy`
```soy
{template .render}
   {delcall ClayCheckbox.Label variant='{$labelVariant}' data="all" /}
{/template}

{deltemplate ClayCheckbox.Label}
   {call .label data="all" /}
{/deltemplate}

{template .label}
   {@param label: html|string}

   <span class="{$spanLabelClasses}">{$label}</span>
{/template}
```

`ClayCard.soy`
```soy
{template .render}
...
   {call Checkbox.render}
      {param coolParameter: 'Wow it's so cool!' /}
      {param label: 'myLabel' /}
      {param labelVariant: 'card' /}
   {/call}
...
{/template}

{deltemplate ClayCheckbox.Label variant="'card'"}
   {call .cardLabel data="all" /}
{/deltemplate}

{template .cardLabel}
   {@param coolParameter: string}
   {@param label: html|string}

   <div class="card">
      {$coolParameter}
      .... {$label} ....
   </div>
{/template}
```

As you can see here we do not have to define everywhere the `coolParameter` but where it's being used, in this case in the `.cardLabel` template inside my `ClayCard` component, and we don't need to worry about the rest of extension that could exists.