### PR TITLE
 Add labelContent support for ClayRadio

### DIFF
--- a/packages/clay-radio/src/ClayRadio.js
+++ b/packages/clay-radio/src/ClayRadio.js
@@ -74,10 +74,20 @@ ClayRadio.STATE = {
 	 * Label of the input. Required for accesibility.
 	 * @instance
 	 * @memberof ClayRadio
-	 * @type {!string|html}
+	 * @type {?string|undefined}
 	 * @default undefined
 	 */
-	label: Config.any().required(),
+	label: Config.string(),
+
+	/**
+	 * Custom content of the radio label. Use it to use your custom html.
+	 * If this is used label and hideLabel params are ignored.
+	 * @instance
+	 * @memberof ClayRadio
+	 * @type {?html|undefined}
+	 * @default undefined
+	 */
+	labelContent: Config.any(),
 
 	/**
 	 * Name to be applied to the element.

--- a/packages/clay-radio/src/ClayRadio.soy
+++ b/packages/clay-radio/src/ClayRadio.soy
@@ -4,13 +4,14 @@
  * This renders an icon element based on the Clay Checkbox definition.
  */
 {template .render}
-	{@param label: html | string}
 	{@param? checked: bool}
 	{@param? disabled: bool}
 	{@param? elementClasses: string}
 	{@param? hideLabel: bool}
 	{@param? id: string}
 	{@param? inline: bool}
+	{@param? label: string}
+	{@param? labelContent: html}
 	{@param? name: string}
 	{@param? value: string}
 
@@ -36,6 +37,7 @@
 			{param disabled: $disabled /}
 			{param hideLabel: $hideLabel /}
 			{param label: $label /}
+			{param labelContent: $labelContent /}
 			{param name: $name /}
 			{param value: $value /}
 		{/call}
@@ -46,10 +48,11 @@
  * This renders the checkbox input
  **/
 {template .input}
-	{@param label: html | string}
 	{@param? checked: bool}
 	{@param? disabled: bool}
 	{@param? hideLabel: bool}
+	{@param? label: string}
+	{@param? labelContent: html}
 	{@param? name: string}
 	{@param? value: string}
 
@@ -82,13 +85,17 @@
 
 		<span class="custom-control-indicator"></span>
 
-		{let $spanLabelClasses kind="text"}
-			custom-control-description
-			{if $hideLabel}
-				{sp}sr-only
-			{/if}
-		{/let}
+		{if $labelContent}
+			{$labelContent}
+		{else}
+			{let $spanLabelClasses kind="text"}
+				custom-control-description
+				{if $hideLabel}
+					{sp}sr-only
+				{/if}
+			{/let}
 
-		<span class="{$spanLabelClasses}">{$label}</span>
+			<span class="{$spanLabelClasses}">{$label}</span>
+		{/if}
 	</label>
 {/template}

--- a/packages/clay-radio/src/__tests__/ClayRadio.js
+++ b/packages/clay-radio/src/__tests__/ClayRadio.js
@@ -98,4 +98,12 @@ describe('ClayRadio', function() {
 
 		expect(clayRadio).toMatchSnapshot();
 	});
+
+	it('should render a radio with custom label content', () => {
+		clayRadio = new ClayRadio({
+			labelContent: '<div><p>My Radio</p></div>',
+		});
+
+		expect(clayRadio).toMatchSnapshot();
+	});
 });

--- a/packages/clay-radio/src/__tests__/__snapshots__/ClayRadio.js.snap
+++ b/packages/clay-radio/src/__tests__/__snapshots__/ClayRadio.js.snap
@@ -40,6 +40,18 @@ exports[`ClayRadio should render a radio with classes 1`] = `
 </div>
 `;
 
+exports[`ClayRadio should render a radio with custom label content 1`] = `
+<div class="custom-control custom-radio">
+  <label>
+    <input class="custom-control-input" ref="input" type="radio" role="radio">
+    <span class="custom-control-indicator"></span>
+    <div>
+      <p>My Radio</p>
+    </div>
+  </label>
+</div>
+`;
+
 exports[`ClayRadio should render a radio with hidden label 1`] = `
 <div class="custom-control custom-radio">
   <label>


### PR DESCRIPTION
Just adding `labelContent` to ClayRadio to do the same as ClayCheckbox.