### PR TITLE
Pass parameter 'data'

### DIFF
--- a/packages/clay-button/src/ClayButton.js
+++ b/packages/clay-button/src/ClayButton.js
@@ -16,7 +16,9 @@ class ClayButton extends Component {
 	 */
 	attached() {
 		for (let dataKey in this.data) {
-			domData.get(this.element, dataKey, this.data[dataKey]);
+			if (this.data.hasOwnProperty(dataKey)) {
+				domData.get(this.element, dataKey, this.data[dataKey]);
+			}
 		}
 	}
 }

--- a/packages/clay-button/src/ClayButton.js
+++ b/packages/clay-button/src/ClayButton.js
@@ -3,13 +3,23 @@ import Component from 'metal-component';
 import defineWebComponent from 'metal-web-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
+import {domData} from 'metal-dom';
 
 import templates from './ClayButton.soy.js';
 
 /**
  * Metal Clay Button component.
  */
-class ClayButton extends Component {}
+class ClayButton extends Component {
+	/**
+	 * @inheritDoc
+	 */
+	attached() {
+		for (let dataKey in this.data) {
+			domData.get(this.element, dataKey, this.data[dataKey]);
+		}
+	}
+}
 
 /**
  * State definition.
@@ -34,6 +44,15 @@ ClayButton.STATE = {
 	 * @default false
 	 */
 	block: Config.bool().value(false),
+
+	/**
+	 * Data to add to the element.
+	 * @instance
+	 * @memberof ClayButton
+	 * @type {?object}
+	 * @default undefined
+	 */
+	data: Config.object(),
 
 	/**
 	 * The button disabled attribute.

--- a/packages/clay-button/src/__tests__/ClayButton.js
+++ b/packages/clay-button/src/__tests__/ClayButton.js
@@ -1,4 +1,5 @@
 import ClayButton from '../ClayButton';
+import {domData} from 'metal-dom';
 
 let button;
 
@@ -142,5 +143,15 @@ describe('ClayButton', function() {
 		});
 
 		expect(button).toMatchSnapshot();
+	});
+
+	it('should render a button with customData attributes', function() {
+		button = new ClayButton({
+			data: {
+				myAttribute: 'myValue',
+			},
+		});
+
+		expect(domData.get(button.element, 'myAttribute')).toEqual('myValue');
 	});
 });

--- a/packages/clay-link/package.json
+++ b/packages/clay-link/package.json
@@ -42,7 +42,7 @@
     "babel-preset-env": "^1.6.0",
     "browserslist-config-clay-components": "^1.0.0-alpha.2",
     "clay": "^2.0.0-beta.2",
-    "metal-dom": "^2.13.2",
+    "metal-dom": "^2.14.0",
     "metal-tools-soy": "^4.2.1",
     "webpack": "^3.0.0"
   },

--- a/packages/clay-link/src/ClayLink.js
+++ b/packages/clay-link/src/ClayLink.js
@@ -16,7 +16,9 @@ class ClayLink extends Component {
 	 */
 	attached() {
 		for (let dataKey in this.data) {
-			domData.get(this.element, dataKey, this.data[dataKey]);
+			if (this.data.hasOwnProperty(dataKey)) {
+				domData.get(this.element, dataKey, this.data[dataKey]);
+			}
 		}
 	}
 }

--- a/packages/clay-link/src/ClayLink.js
+++ b/packages/clay-link/src/ClayLink.js
@@ -3,13 +3,23 @@ import Component from 'metal-component';
 import defineWebComponent from 'metal-web-component';
 import Soy from 'metal-soy';
 import {Config} from 'metal-state';
+import {domData} from 'metal-dom';
 
 import templates from './ClayLink.soy.js';
 
 /**
  * Implementation of the Metal Clay Link.
  */
-class ClayLink extends Component {}
+class ClayLink extends Component {
+	/**
+	 * @inheritDoc
+	 */
+	attached() {
+		for (let dataKey in this.data) {
+			domData.get(this.element, dataKey, this.data[dataKey]);
+		}
+	}
+}
 
 /**
  * State definition.
@@ -44,6 +54,15 @@ ClayLink.STATE = {
 	 * @default undefined
 	 */
 	buttonStyle: Config.oneOf(['borderless', 'link', 'primary', 'secondary']),
+
+	/**
+	 * Data to add to the element.
+	 * @instance
+	 * @memberof ClayButton
+	 * @type {?object}
+	 * @default undefined
+	 */
+	data: Config.object(),
 
 	/**
 	 * Sets the download attribute on the anchor tag.

--- a/packages/clay-link/src/ClayLink.js
+++ b/packages/clay-link/src/ClayLink.js
@@ -49,7 +49,7 @@ ClayLink.STATE = {
 	 * The css class to act as a button. If this is defined `style` param is
 	 * ignored.
 	 * @instance
-	 * @memberof ClayButton
+	 * @memberof ClayLink
 	 * @type {?string|undefined}
 	 * @default undefined
 	 */
@@ -58,7 +58,7 @@ ClayLink.STATE = {
 	/**
 	 * Data to add to the element.
 	 * @instance
-	 * @memberof ClayButton
+	 * @memberof ClayLink
 	 * @type {?object}
 	 * @default undefined
 	 */
@@ -125,7 +125,7 @@ ClayLink.STATE = {
 	/**
 	 * The css class that colors the button.
 	 * @instance
-	 * @memberof ClayButton
+	 * @memberof ClayLink
 	 * @type {?string|undefined}
 	 * @default undefined
 	 */

--- a/packages/clay-link/src/__tests__/ClayLink.js
+++ b/packages/clay-link/src/__tests__/ClayLink.js
@@ -1,4 +1,5 @@
 import ClayLink from '../ClayLink';
+import {domData} from 'metal-dom';
 
 let link;
 
@@ -159,5 +160,15 @@ describe('ClayLink', function() {
 		});
 
 		expect(link).toMatchSnapshot();
+	});
+
+	it('should render a link with customData attributes', function() {
+		link = new ClayLink({
+			data: {
+				myAttribute: 'myValue',
+			},
+		});
+
+		expect(domData.get(link.element, 'myAttribute')).toEqual('myValue');
 	});
 });


### PR DESCRIPTION
Once component is attached all data attributes passed are bounded to the element and can be retrieved with metal domData:

`domData.get(component.element, 'dataAttributeName')`

You can also retrieve it from the element received in an event, for example:

```soy
{call ClayLink.render}
   {param data: ['myAttr': 'myValue'] /}
   {param events: ['click': $myHandler_] /}
   {param label: 'My Link' /}
{/call}
```
```js
myHandler_(event) {
   console.log(domData.get(event.target, 'myAttr')); //Console output would be 'myValue'
}
```

This solves https://github.com/metal/metal-clay-components/issues/144