### PR TITLE
Update ClayButton markup

### DIFF
--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -57,20 +57,42 @@
 	{@param? label: html|string}
 	{@param? spritemap: string}
 
+	{let $classes kind="text"}
+		inline-item
+		{if $iconAlignment == 'left' and $label}
+			{sp}inline-item-before
+		{elseif $iconAlignment == 'right' and $label}
+			{sp}inline-item-after
+		{/if}
+	{/let}
+
+	{let $iconContent kind="html"}
+		{if $icon and $spritemap}
+			{call .icon}
+				{param icon: $icon /}
+				{param spritemap: $spritemap /}
+			{/call}
+		{/if}
+	{/let}
+
+	{let $iconWrapper kind="html"}
+		{if $label}
+			<span class="{$classes}">
+				{$iconContent}
+			</span>
+		{else}
+			{$iconContent}
+		{/if}
+	{/let}
+
 	{if $icon and $iconAlignment == 'left' and $spritemap}
-		{call .icon}
-			{param icon: $icon /}
-			{param spritemap: $spritemap /}
-		{/call}
+		{$iconWrapper}
 	{/if}
 
 	{$label ?: ''}
 
 	{if $icon and $iconAlignment == 'right' and $spritemap}
-		{call .icon}
-			{param icon: $icon /}
-			{param spritemap: $spritemap /}
-		{/call}
+		{$iconWrapper}
 	{/if}
 {/template}
 

--- a/packages/clay-button/src/ClayButton.soy
+++ b/packages/clay-button/src/ClayButton.soy
@@ -59,9 +59,9 @@
 
 	{let $classes kind="text"}
 		inline-item
-		{if $iconAlignment == 'left' and $label}
+		{if $iconAlignment == 'left'}
 			{sp}inline-item-before
-		{elseif $iconAlignment == 'right' and $label}
+		{elseif $iconAlignment == 'right'}
 			{sp}inline-item-after
 		{/if}
 	{/let}

--- a/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
+++ b/packages/clay-button/src/__tests__/__snapshots__/ClayButton.js.snap
@@ -15,10 +15,12 @@ exports[`ClayButton should render a button with icon 1`] = `
 
 exports[`ClayButton should render a button with icon and label 1`] = `
 <button class="btn btn-primary" type="button">
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
-    <title>plus</title>
-    <use xlink:href="icons.svg#plus"></use>
-  </svg>Label</button>
+  <span class="inline-item inline-item-before">
+    <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
+      <title>plus</title>
+      <use xlink:href="icons.svg#plus"></use>
+    </svg>
+  </span>Label</button>
 `;
 
 exports[`ClayButton should render a button with icon and monospaced true 1`] = `
@@ -38,18 +40,22 @@ exports[`ClayButton should render a button with label and ariaLabel 1`] = `<butt
 
 exports[`ClayButton should render a button with label and icon 1`] = `
 <button class="btn btn-primary" type="button">
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
-    <title>plus</title>
-    <use xlink:href="icons.svg#plus"></use>
-  </svg>Label</button>
+  <span class="inline-item inline-item-before">
+    <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
+      <title>plus</title>
+      <use xlink:href="icons.svg#plus"></use>
+    </svg>
+  </span>Label</button>
 `;
 
 exports[`ClayButton should render a button with label and icon on right side 1`] = `
 <button class="btn btn-primary" type="button">Label
-  <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
-    <title>plus</title>
-    <use xlink:href="icons.svg#plus"></use>
-  </svg>
+  <span class="inline-item inline-item-after">
+    <svg aria-hidden="true" class="lexicon-icon lexicon-icon-plus">
+      <title>plus</title>
+      <use xlink:href="icons.svg#plus"></use>
+    </svg>
+  </span>
 </button>
 `;
 

--- a/packages/clay-table/src/__tests__/__snapshots__/ClayTable.js.snap
+++ b/packages/clay-table/src/__tests__/__snapshots__/ClayTable.js.snap
@@ -129,10 +129,12 @@ exports[`ClayTable should render a ClayTable with a basic schema with sortable f
       <tr>
         <th class="table-cell-expand">
           <button class="btn btn-unstyled" type="button">Title
-            <svg aria-hidden="true" class="lexicon-icon lexicon-icon-order-arrow-up">
-              <title>order-arrow-up</title>
-              <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#order-arrow-up"></use>
-            </svg>
+            <span class="inline-item inline-item-after">
+              <svg aria-hidden="true" class="lexicon-icon lexicon-icon-order-arrow-up">
+                <title>order-arrow-up</title>
+                <use xlink:href="../node_modules/lexicon-ux/build/images/icons/icons.svg#order-arrow-up"></use>
+              </svg>
+            </span>
           </button>
         </th>
         <th>


### PR DESCRIPTION
It is necessary that do not add a `span` when you just want to render an **icon**, this causes some unwanted behaviors in some components like **ClayLabel**.